### PR TITLE
Fix detection loop continuing after stop causing WebGL error

### DIFF
--- a/focus-proctor/src/main.ts
+++ b/focus-proctor/src/main.ts
@@ -22,6 +22,8 @@ let lastObjectCheck = 0;
 let focusLostLogged = false;
 let noFaceLogged = false;
 let multiFaceLogged = false;
+let detecting = false;
+let animationId = 0;
 
 function logEvent(msg: string) {
   const li = document.createElement('li');
@@ -47,12 +49,15 @@ async function start() {
   recorder.start();
   lastFaceTime = Date.now();
   lastFocusedTime = Date.now();
+  detecting = true;
   detect();
   stopBtn.disabled = false;
 }
 
 function stop() {
   stopBtn.disabled = true;
+  detecting = false;
+  cancelAnimationFrame(animationId);
   recorder.stop();
   stream.getTracks().forEach((t) => t.stop());
   const blob = new Blob(recordingChunks, { type: 'video/webm' });
@@ -65,6 +70,7 @@ function stop() {
 }
 
 async function detect() {
+  if (!detecting) return;
   canvas.width = video.videoWidth;
   canvas.height = video.videoHeight;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -123,7 +129,9 @@ async function detect() {
     });
   }
 
-  requestAnimationFrame(detect);
+  if (detecting) {
+    animationId = requestAnimationFrame(detect);
+  }
 }
 
 startBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Stop camera detection loop when recording stops by tracking animation frame and detection state.
- Guard detection routine so it exits when not active and only schedules frames while running.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7f6b53590832cbf1053d83eaf5eb2