### PR TITLE
Clear logs and state on restart

### DIFF
--- a/focus-proctor/src/main.ts
+++ b/focus-proctor/src/main.ts
@@ -40,6 +40,11 @@ async function initModels() {
 
 async function start() {
   startBtn.disabled = true;
+  logs.innerHTML = '';
+  focusLostLogged = false;
+  noFaceLogged = false;
+  multiFaceLogged = false;
+  recordingChunks.length = 0;
   await initModels();
   stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
   video.srcObject = stream;
@@ -49,6 +54,7 @@ async function start() {
   recorder.start();
   lastFaceTime = Date.now();
   lastFocusedTime = Date.now();
+  lastObjectCheck = Date.now();
   detecting = true;
   detect();
   stopBtn.disabled = false;


### PR DESCRIPTION
## Summary
- Clear previous log entries and state when starting detection
- Reset object detection timer to ensure immediate scans

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7f8c8ea0c832c8f20df46cdd5fb8c