### PR TITLE
Preload models to remove start delay

### DIFF
--- a/focus-proctor/index.html
+++ b/focus-proctor/index.html
@@ -12,7 +12,7 @@
       <canvas id="overlay"></canvas>
     </div>
     <div id="controls">
-      <button id="startBtn">Start</button>
+      <button id="startBtn" disabled>Start</button>
       <button id="stopBtn" disabled>Stop</button>
     </div>
     <h2>Event Log</h2>

--- a/focus-proctor/src/main.ts
+++ b/focus-proctor/src/main.ts
@@ -10,6 +10,8 @@ const logs = document.getElementById('logs') as HTMLUListElement;
 const startBtn = document.getElementById('startBtn') as HTMLButtonElement;
 const stopBtn = document.getElementById('stopBtn') as HTMLButtonElement;
 
+startBtn.disabled = true;
+
 let faceModel: blazeface.BlazeFaceModel;
 let objectModel: cocoSsd.ObjectDetection;
 let stream: MediaStream;
@@ -38,6 +40,10 @@ async function initModels() {
   ]);
 }
 
+const modelPromise = initModels().finally(() => {
+  startBtn.disabled = false;
+});
+
 async function start() {
   startBtn.disabled = true;
   logs.innerHTML = '';
@@ -45,7 +51,7 @@ async function start() {
   noFaceLogged = false;
   multiFaceLogged = false;
   recordingChunks.length = 0;
-  await initModels();
+  await modelPromise;
   stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
   video.srcObject = stream;
   await video.play();


### PR DESCRIPTION
## Summary
- Disable the start button until required TensorFlow models are loaded
- Load face and object detection models on page load so starting capture is faster

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7fd7d1b28832c9d29446826921ed7