### PR TITLE
Configure Vercel build for focus-proctor subdirectory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "installCommand": "npm install --prefix focus-proctor",
+  "buildCommand": "npm run build --prefix focus-proctor",
+  "outputDirectory": "focus-proctor/dist"
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration so the build and install commands run from the focus-proctor folder
- point the deployment output directory at the Vite dist folder inside the subproject

## Testing
- npm install --prefix focus-proctor
- npm run build --prefix focus-proctor

------
https://chatgpt.com/codex/tasks/task_e_68c83abc1b08832c89a310ee27430c43